### PR TITLE
Fix: Corrected expected title in login page validation scenario

### DIFF
--- a/features/login.feature
+++ b/features/login.feature
@@ -5,7 +5,7 @@ Feature: Login Feature
 
   Scenario: Validate the login page title
     # TODO: Fix this failing scenario
-    Then I should see the title "Labs Swag"
+    Then I should see the title "Swag Labs"
 
   Scenario: Validate login error message
     Then I will login as 'locked_out_user'


### PR DESCRIPTION
Updated `login.feature` to correct the expected title from "Labs Swag" to "Swag Labs"
Scenario now passes with correct page title assertion
No code logic changes needed in page object

Scenario passing
Branch: feature/Validate_the_login_page_title
